### PR TITLE
Change timeout after stopping solr.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,4 @@ solr_home_path: /var/data/solr
 solr_home_owner: root
 solr_home_group: root
 solr_home_mode: 755
+solr_java_memory_options: "-Xmx128M -Xms64M -XX:MaxPermSize=64M -Xmn32M"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,3 +14,4 @@ galaxy_info:
   categories:
     - web
     - database
+dependencies: []

--- a/templates/initscript.j2
+++ b/templates/initscript.j2
@@ -35,7 +35,7 @@ export PATH=/sbin:/usr/sbin:/bin:/usr/bin
 # The following variables can be overwritten in $DEFAULT
 
 if [ -z "$JAVA_OPTS" ]; then
- JAVA_OPTS="-Djava.awt.headless=true -Dsolr.solr.home={{ solr_home_path }}"
+ JAVA_OPTS="-Djava.awt.headless=true -Dsolr.solr.home={{ solr_home_path }} {{ solr_java_memory_options }}"
 fi
 
 # End of variables that can be overwritten in $DEFAULT

--- a/templates/initscript.j2
+++ b/templates/initscript.j2
@@ -92,7 +92,7 @@ case "$1" in
                 ;;
         restart|force-reload)
                 $0 stop
-                sleep 1
+                sleep 3
                 $0 start
                 ;;
         status)

--- a/templates/initscript.j2
+++ b/templates/initscript.j2
@@ -81,7 +81,7 @@ case "$1" in
                 start-stop-daemon --stop --quiet --pidfile $SOLRPID
                 log_progress_msg "solr"
                 # Wait a little and remove stale PID file
-                sleep 1
+                sleep 4
                 if [ -f $SOLRPID ] && ! ps h `cat $SOLRPID` > /dev/null
                 then
                         # Stale PID file (solr was succesfully stopped),
@@ -92,7 +92,7 @@ case "$1" in
                 ;;
         restart|force-reload)
                 $0 stop
-                sleep 4
+                sleep 1
                 $0 start
                 ;;
         status)


### PR DESCRIPTION
Sometimes our playbooks fail because of this role.
The reason is that stopping the solr server sometimes takes longer than 1 second and the solr PID doesn't get removed.

Changing the timeout between stopping and removing PIDFILE to 4 seconds solves the issue.

Then we can also reduce the sleep between stop and start in the restart part of the script to 1 second.
